### PR TITLE
feature/TAG-7-give-users-tag-formatting-settings-choice

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,12 @@
 		"build-css": "rm -rf ./dist/*.css && npx tailwindcss -i ./styles.css -o ./dist/styles.css",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
-	"keywords": ["plugin", "obsidian", "tag", "classification"],
+	"keywords": [
+		"plugin",
+		"obsidian",
+		"tag",
+		"classification"
+	],
 	"author": "Control Alt",
 	"license": "MIT",
 	"devDependencies": {
@@ -33,6 +38,7 @@
 	},
 	"dependencies": {
 		"axios": "^1.4.0",
+		"change-case": "^5.1.2",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"tailwindcss": "^3.3.3",

--- a/src/plugin/settings/settings.ts
+++ b/src/plugin/settings/settings.ts
@@ -7,6 +7,7 @@ export interface AutoTagPluginSettings {
 	useAutotagPrefix: boolean;
 	useFrontmatterAutotagsKey: boolean;
 	tagsToInsert: number;
+	tagsFormat: "kebabCase"|"snakeCase"|"pascalCase"|"camelCase"| "pascalSnakeCase"|"trainCase"|"constantCase";
 	showPreUpdateDialog: boolean;
 	showPostUpdateDialog: boolean;
 	demoMode: boolean;
@@ -19,6 +20,7 @@ export const DEFAULT_SETTINGS: AutoTagPluginSettings = {
 	useAutotagPrefix: true,
 	useFrontmatterAutotagsKey: false,
 	tagsToInsert: 3,
+	tagsFormat: "kebabCase",
 	showPreUpdateDialog: true,
 	showPostUpdateDialog: true,
 	demoMode: true,
@@ -101,6 +103,23 @@ export class AutoTagSettingTab extends PluginSettingTab {
 		.setValue(`${this.plugin.settings.tagsToInsert}`)
 		.onChange(async (value) => {
 			this.plugin.settings.tagsToInsert = parseInt(value);
+			await this.plugin.saveSettings();
+		}));
+
+		new Setting(containerEl)
+		.setName('How to format tags?')
+		.setDesc('You can indicate your own preference. Only applies to new suggested tags, does not update existing tags.')
+		.addDropdown(dropdown => dropdown
+		.addOption("kebabCase", 'two-words (kebak case)')
+		.addOption("snakeCase", 'two_words (snake case)')
+		.addOption("pascalCase", 'TwoWords (pascal case)')
+		.addOption("camelCase", 'twoWords (camel case)')
+		.addOption("pascalSnakeCase", 'Two_Words (pascal snake case)')
+		.addOption("trainCase", 'Two-Words (train case)')
+		.addOption("constantCase", 'TWO_WORDS (constant case)')
+		.setValue(`${this.plugin.settings.tagsFormat}`)
+		.onChange(async (value) => {
+			this.plugin.settings.tagsFormat = value as AutoTagPluginSettings["tagsFormat"];
 			await this.plugin.saveSettings();
 		}));
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -32,3 +32,25 @@ export const createDocumentFragment = (htmlString: string, unsafeValues: Record<
 
 	return fragment;
 }
+
+/**
+ * Used when applying formatting to tags.
+ * For some languages, the change-case library outputs a wrong result, so
+ * we handle it in a simpler custom manner.
+ *
+ * @param tag
+ * @param format
+ */
+export function customCaseConversion(tag: string, format: string): string {
+	switch (format) {
+		case 'kebabCase':
+		case 'trainCase':
+			return tag.replace(/\s+/g, '-');
+		case 'snakeCase':
+		case 'pascalSnakeCase':
+			return tag.replace(/\s+/g, '_');
+		default:
+			return tag;  // No conversion for unsupported formats
+	}
+}
+


### PR DESCRIPTION
Implements a setting option to let user choose how to format tags. Also added sample tags in 10 languages, so that all users can see the effect of this choice on tags in tags for their language (this will matter once tags for non-english languages are implemented).

- two-words (kebak case)
- two_words (snake case)
- TwoWords (pascal case)
- twoWords (camel case)
- Two_Words (pascal snake case)
- Two-Words (train case)
- TWO_WORDS (constant case)

<img width="633" alt="image" src="https://github.com/CtrlAltFocus/obsidian-plugin-auto-tag/assets/128191353/aba53008-75ff-4b54-b12a-5efdb5c41d3e">

<img width="365" alt="image" src="https://github.com/CtrlAltFocus/obsidian-plugin-auto-tag/assets/128191353/97786dd8-9d5d-4420-8097-f7cc56c1057d">

