### PR TITLE
Add support for different models, existing tags

### DIFF
--- a/src/businesslogic/insertTags.ts
+++ b/src/businesslogic/insertTags.ts
@@ -230,7 +230,7 @@ export const commandFnInsertTagsForSelectedText = async (editor: Editor, view: M
 		 * Retrieve tag suggestions.
 		 */
 		const suggestedTags = await getAutoTags(selectedText, allExistingTags, settings) || [];
-		const finalTags = suggestedTags.filter(x => !allExistingTags.includes(x));
+		const finalTags = suggestedTags.filter(x => !pageExistingTags.includes(x));
 
 		/**
 		 * Insert the tags in the note right away.

--- a/src/businesslogic/insertTags.ts
+++ b/src/businesslogic/insertTags.ts
@@ -208,10 +208,7 @@ export const commandFnInsertTagsForSelectedText = async (editor: Editor, view: M
 	if (settings.showPreUpdateDialog) {
 		const fetchTagsFunction = async () => {
 			const suggestedTags = await getAutoTags(selectedText, allExistingTags, settings);
-			const finalTags = suggestedTags.filter(x => !pageExistingTags.includes(x));
-
-			AutoTagPlugin.Logger.log('pageTags: ' + pageExistingTags + ', finalTags: ' + finalTags);
-			return finalTags;
+			return suggestedTags.filter(x => !pageExistingTags.includes(x));
 		};
 
 		const onAccept = async (acceptedTags: string[]) => {

--- a/src/businesslogic/insertTags.ts
+++ b/src/businesslogic/insertTags.ts
@@ -202,15 +202,15 @@ export const commandFnInsertTagsForSelectedText = async (editor: Editor, view: M
 		return;
 	}
 
-	const allExistingTags = await getKnownTags(view.app);
-	const pageExistingTags = await getKnownTags(view.app, view.file);
+	const fetchTagsFunction = async () => {
+		const allExistingTags = await getKnownTags(view.app);
+		const pageExistingTags = await getKnownTags(view.app, view.file);
+		const suggestedTags = await getAutoTags(selectedText, allExistingTags, settings) || [];
+
+		return suggestedTags.filter(x => !pageExistingTags.includes(x));
+	};
 
 	if (settings.showPreUpdateDialog) {
-		const fetchTagsFunction = async () => {
-			const suggestedTags = await getAutoTags(selectedText, allExistingTags, settings);
-			return suggestedTags.filter(x => !pageExistingTags.includes(x));
-		};
-
 		const onAccept = async (acceptedTags: string[]) => {
 			AutoTagPlugin.Logger.debug("Tags accepted for insertion:", acceptedTags);
 
@@ -229,8 +229,7 @@ export const commandFnInsertTagsForSelectedText = async (editor: Editor, view: M
 		/**
 		 * Retrieve tag suggestions.
 		 */
-		const suggestedTags = await getAutoTags(selectedText, allExistingTags, settings) || [];
-		const finalTags = suggestedTags.filter(x => !pageExistingTags.includes(x));
+		const finalTags = await fetchTagsFunction();
 
 		/**
 		 * Insert the tags in the note right away.

--- a/src/businesslogic/knownTags.ts
+++ b/src/businesslogic/knownTags.ts
@@ -1,33 +1,18 @@
-import { App } from "obsidian";
+import {App, getAllTags, TFile} from "obsidian";
 
-export const getKnownTags = async (app: App): Promise<string[]> => {
+export const getKnownTags = async (app: App, file: TFile | null = null): Promise<string[]> => {
     const { vault, metadataCache } = app;
     const tags: string[] = [];
 
-    // // See how much text was processed:
-    // const fileContents: string[] = await Promise.all(
-    //     vault.getMarkdownFiles().map(async (file) => vault.cachedRead(file))
-    // );
-    // let totalLength = 0;
-    // fileContents.forEach((content) => {
-    //     totalLength += content.length;
-    // });
+	const mkdFiles = file ? [file] : vault.getMarkdownFiles();
 
-    vault.getMarkdownFiles().forEach((file, index) => {
-        metadataCache.getFileCache(file)?.tags?.forEach((tag) => {
-            if (!tags.includes(tag.tag)) {
-                tags.push(tag.tag);
-            }
-        });
-
-        // TODO Separate #autotags/... from other tags
-
-        // TODO Could also use this to get the autotags: from frontmatter
-        // metadataCache.getFileCache(file)?.frontmatter?. ....
-        // Can also get headings, list items, blocks, embeds, etc. see CachedMetadata
+    mkdFiles.forEach((file, index) => {
+		const mdc = metadataCache.getFileCache(file);
+		if (mdc) {
+			const x = getAllTags(mdc) || [];
+			tags.push(...x)
+		}
     });
 
-    // AutoTagPlugin.Logger.debug(`Found ${tags.length} tags in ${fileContents.length} files with a total length of ${totalLength} characters.`);
-
-    return tags;
+    return tags.map(tag => tag.replace('#', ''));
 }

--- a/src/plugin/modals/preUpdateModal/components/TagsPreviewList.tsx
+++ b/src/plugin/modals/preUpdateModal/components/TagsPreviewList.tsx
@@ -52,6 +52,22 @@ export function TagsPreviewList(props: TagsPreviewListProps): JSX.Element {
 		return () => clearTimeout(timeout);
 	}, [isLoading]);
 
+	if (!isLoading && !tags.length) {
+		setTimeout(onCancel, 3000);
+
+		return (
+			<div>
+				<div>No new tags!</div>
+				<button
+					onClick={onCancel}
+					className="btn btn-secondary"
+				>
+					OK
+				</button>
+			</div>
+		)
+	}
+
 	return (
 		<div>
 			{isLoading ? <div>

--- a/src/plugin/settings/settings.ts
+++ b/src/plugin/settings/settings.ts
@@ -174,7 +174,7 @@ export class AutoTagSettingTab extends PluginSettingTab {
 		.setName(`OpenAI API model`)
 		.setDesc(createDocumentFragment(`The OpenAI model used to generate tags.`))
 		.addDropdown(dropdown => {
-				OPENAI_API_MODELS.map(model => dropdown.addOption(model.id, model.name));
+				OPENAI_API_MODELS.forEach(model => dropdown.addOption(model.id, model.name));
 				dropdown.setValue(`${this.plugin.settings.openaiModel.id}`);
 				dropdown.onChange(async (value) => {
 					this.plugin.settings.openaiModel = OPENAI_API_MODELS.find(model => model.id === value) || OPENAI_API_MODELS[0];

--- a/src/plugin/settings/settings.ts
+++ b/src/plugin/settings/settings.ts
@@ -3,6 +3,8 @@ import AutoTagPlugin from "../autoTagPlugin";
 import {createDocumentFragment} from "src/utils/utils";
 import {OPENAI_API_MODELS} from "../../services/openaiModelsList";
 import {LlmModel} from "../../services/models/openai.models";
+import {Simulate} from "react-dom/test-utils";
+import drop = Simulate.drop;
 
 export interface AutoTagPluginSettings {
 	useAutotagPrefix: boolean;
@@ -170,7 +172,16 @@ export class AutoTagSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 		.setName(`OpenAI API model`)
-		.setDesc(createDocumentFragment(`The OpenAI <strong>GPT-3.5 Turbo model</strong> is used by default (rather than GPT-4) as it's really good for this task and the cheapest choice. Contact me if this is not enough for your needs.`));
+		.setDesc(createDocumentFragment(`The OpenAI model used to generate tags.`))
+		.addDropdown(dropdown => {
+				OPENAI_API_MODELS.map(model => dropdown.addOption(model.id, model.name));
+				dropdown.setValue(`${this.plugin.settings.openaiModel.id}`);
+				dropdown.onChange(async (value) => {
+					this.plugin.settings.openaiModel = OPENAI_API_MODELS.find(model => model.id === value) || OPENAI_API_MODELS[0];
+					await this.plugin.saveSettings();
+				});
+			}
+		)
 
 		new Setting(containerEl)
 		.setName(`Predictability of the results`)

--- a/src/services/openai.api.ts
+++ b/src/services/openai.api.ts
@@ -7,7 +7,7 @@ import {AutoTagPluginSettings} from "../plugin/settings/settings";
 const OPENAI_API_URL = 'https://api.openai.com/v1/chat/completions';
 
 // const llmPromptTagSuggestionsAlternative  = 'You are ChatGPT, a helpful multi-lingual assistant and text analysis tool. You help with semantic understanding and text classification of received user input text and provide suggestions for tags that best allow to categorize and identify the text, for use in search engines or content linking and grouping or semantic search of related content. You will receive the input text from the user, delimited by the --start-- and --end-- tags. Consider the context of the text, reason step by step about what it is about, then suggest tags that best describe the user\'s text. Rather than specific to this text, it should grasp the topic and meaning so that the tags can help find other related similar content.';
-const llmPromptTagSuggestions = 'You are ChatGPT, a helpful multi-lingual assistant and text analysis tool. You help with semantic understanding and text classification of received user input text and provide suggestions for tags that best allow to categorize and identify the text, for use in search engines or content linking and grouping or semantic search of related content. You will receive the input text from the user, delimited by the --start-- and --end-- tags. Existing tags to consider using are below, between <existingTags> and </existingTags>. Consider the context of the text, what is it about if you take a step back? Suggest tags that best describe the user\'s text. Rather than specific to this text, it should grasp the topic and meaning so that the tags can help find other related similar content.';
+const llmPromptTagSuggestions = 'You are ChatGPT, a helpful multi-lingual assistant and text analysis tool. You help with semantic understanding and text classification of received user input text and provide suggestions for tags that best allow to categorize and identify the text, for use in search engines or content linking and grouping or semantic search of related content. You will receive the input text from the user, delimited by <text> and </text>. Existing tags to consider using are below, between <existingTags> and </existingTags>. Consider the context of the text, what is it about if you take a step back? Suggest tags that best describe the user\'s text. Rather than specific to this text, it should grasp the topic and meaning so that the tags can help find other related similar content. Always try to generate at least 7 tags.';
 
 const gptTagHandlingFunctionDescription = 'This function needs to receive a list of tags, that you suggest based on the best matching tags that describe the user-provided input text. Return at least 1 tag. Return at most 10 tags. The tags should be in the language of the user-provided input text.';
 
@@ -70,7 +70,7 @@ export function getOpenAIFunctionCallBody(settings: AutoTagPluginSettings, input
 			},
 			{
 				role: 'user',
-				content: "--start--\n" + inputText + "\n--end--\n\n<existingTags>\n" + knownTags + "\n</existingTags>",
+				content: "<text>\n" + inputText + "\n</text>\n\n<existingTags>\n" + knownTags + "\n</existingTags>",
 			},
 		],
 		functions: [gptFunction],

--- a/src/services/openai.api.ts
+++ b/src/services/openai.api.ts
@@ -7,9 +7,9 @@ import {AutoTagPluginSettings} from "../plugin/settings/settings";
 const OPENAI_API_URL = 'https://api.openai.com/v1/chat/completions';
 
 // const llmPromptTagSuggestionsAlternative  = 'You are ChatGPT, a helpful multi-lingual assistant and text analysis tool. You help with semantic understanding and text classification of received user input text and provide suggestions for tags that best allow to categorize and identify the text, for use in search engines or content linking and grouping or semantic search of related content. You will receive the input text from the user, delimited by the --start-- and --end-- tags. Consider the context of the text, reason step by step about what it is about, then suggest tags that best describe the user\'s text. Rather than specific to this text, it should grasp the topic and meaning so that the tags can help find other related similar content.';
-const llmPromptTagSuggestions = 'You are ChatGPT, a helpful multi-lingual assistant and text analysis tool. You help with semantic understanding and text classification of received user input text and provide suggestions for tags that best allow to categorize and identify the text, for use in search engines or content linking and grouping or semantic search of related content. You will receive the input text from the user, delimited by <text> and </text>. Existing tags to consider using are below, between <existingTags> and </existingTags>. Consider the context of the text, what is it about if you take a step back? Suggest tags that best describe the user\'s text. Rather than specific to this text, it should grasp the topic and meaning so that the tags can help find other related similar content. Always try to generate at least 7 tags.';
+const llmPromptTagSuggestions = 'You are ChatGPT, a helpful multi-lingual assistant and text analysis tool. You help with semantic understanding and text classification of received user input text and provide suggestions for tags that best allow to categorize and identify the text, for use in search engines or content linking and grouping or semantic search of related content. You will receive the input text from the user, delimited by <text> and </text>. Existing tags to consider using are below, between <existingTags> and </existingTags>. Consider the context of the text, what is it about if you take a step back? Suggest tags that best describe the user\'s text. The tags should grasp the topic and meaning so that the tags can help find other related similar content. Always create tags for names and places found in the text. Always try to generate at least 5 tags, and at most 15 tags.';
 
-const gptTagHandlingFunctionDescription = 'This function needs to receive a list of tags, that you suggest based on the best matching tags that describe the user-provided input text. Return at least 1 tag. Return at most 10 tags. The tags should be in the language of the user-provided input text.';
+const gptTagHandlingFunctionDescription = 'This function needs to receive a list of tags, that you suggest based on the best matching tags that describe the user-provided input text. The tags should be in the language of the user-provided input text.';
 
 export const gptFunction: GptFunction = {
 	name: 'handleTagSuggestions',
@@ -61,12 +61,12 @@ export async function getTagSuggestions(settings: AutoTagPluginSettings, inputTe
 export function getOpenAIFunctionCallBody(settings: AutoTagPluginSettings, inputText: string, knownTags: string[]) {
 	return JSON.stringify({
 		model: settings.openaiModel.id,
-		max_tokens: 350, // could set a multiple of the max number of tags desired
+		max_tokens: settings.openaiModel.parameters?.maxTokens, // could set a multiple of the max number of tags desired
 		temperature: settings.openaiTemperature,
 		messages: [
 			{
 				role: 'system',
-				content: llmPromptTagSuggestions
+				content: llmPromptTagSuggestions,
 			},
 			{
 				role: 'user',

--- a/src/services/openaiModelsList.ts
+++ b/src/services/openaiModelsList.ts
@@ -2,12 +2,20 @@ import {LlmModel} from "./models/openai.models";
 
 export const OPENAI_API_MODELS: LlmModel[] = [
 	{
-		id: "gpt-3.5-turbo-1106",
-		name: "GPT-3.5 Turbo (1106)",
+		id: "gpt-3.5-turbo",
+		name: "GPT-3.5 Turbo",
 		features: ["function-calling"],
 		context: 16000,
-		inputCost1KTokens: 0.0010,
-		outputCost1KTokens: 0.0020
+		inputCost1KTokens: 0.0005,
+		outputCost1KTokens: 0.0015
+	},
+	{
+		id: "gpt-4o-mini",
+		name: "GPT-4o mini",
+		features: ["function-calling"],
+		context: 16384,
+		inputCost1KTokens: 0.00015,
+		outputCost1KTokens: 0.00060
 	}
 	// For now no point in using GPT-4, it's not much better than GPT-3.5 Turbo for this task and more expensive
 	// {


### PR DESCRIPTION
This PR adds ability to change the model used to generate the tags (gpt-4o-mini, better and cheaper than 3.5 turbo). It also sends all of the existing tags to improve tag generation for better graph relevance. Also prevents adding duplicate tags.